### PR TITLE
[build] try macOS ventura pool

### DIFF
--- a/.github/workflows/spice.yml
+++ b/.github/workflows/spice.yml
@@ -21,6 +21,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
     - name: install .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/spice.yml
+++ b/.github/workflows/spice.yml
@@ -21,7 +21,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: maxim-lobanov/setup-xcode@v1
+    - name: select Xcode version
+      uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
 

--- a/.github/workflows/spice.yml
+++ b/.github/workflows/spice.yml
@@ -10,7 +10,7 @@ jobs:
 
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-13
 
     env:
       Configuration: Release


### PR DESCRIPTION
Context: https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/

We need Xcode 14.3.