### PR TITLE
Fix `MA002` warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,5 +11,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <PackageOutputPath>$(MSBuildThisFileDirectory)bin/$(Configuration)/</PackageOutputPath>
+    <WarningsAsErrors>MA002</WarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,4 +3,7 @@
     <!-- Weird fix for VS Mac -->
     <CreatePackage Condition=" '$(TargetFramework)' == 'net8.0-ios' ">false</CreatePackage>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Maui.Resizetizer" Version="8.0.3" />
+  </ItemGroup>
 </Project>

--- a/samples/HeadToHeadSpice/HeadToHeadSpice.csproj
+++ b/samples/HeadToHeadSpice/HeadToHeadSpice.csproj
@@ -40,6 +40,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Spice\Spice.csproj" />
+		<PackageReference Include="Microsoft.Maui.Resizetizer" />
 	</ItemGroup>
 
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/samples/Spice.BlazorSample/Spice.BlazorSample.csproj
+++ b/samples/Spice.BlazorSample/Spice.BlazorSample.csproj
@@ -42,6 +42,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Spice\Spice.csproj" />
+        <PackageReference Include="Microsoft.Maui.Resizetizer" />
     </ItemGroup>
 
     <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />

--- a/samples/Spice.Scenarios/Spice.Scenarios.csproj
+++ b/samples/Spice.Scenarios/Spice.Scenarios.csproj
@@ -41,6 +41,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Spice\Spice.csproj" />
+        <PackageReference Include="Microsoft.Maui.Resizetizer" />
     </ItemGroup>
 
     <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/src/Spice.Templates/templates/spice-blazor/HelloBlazor.csproj
+++ b/src/Spice.Templates/templates/spice-blazor/HelloBlazor.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spice" Version="*-*" />
+    <PackageReference Include="Microsoft.Maui.Resizetizer" Version="$(MauiVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Spice.Templates/templates/spice/Hello.csproj
+++ b/src/Spice.Templates/templates/spice/Hello.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spice" Version="*-*" />
+    <PackageReference Include="Microsoft.Maui.Resizetizer" Version="$(MauiVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I made this warning an error, and fixed the various projects & .NET 8 spice templates.