### PR TITLE
Add Copilot setup GitHub Actions workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,31 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      WORKLOAD_VERSION: 10.0.103
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: install .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: install workloads
+        run: dotnet workload install maui-android --version $WORKLOAD_VERSION


### PR DESCRIPTION
Add a new GitHub Actions workflow (.github/workflows/copilot-setup-steps.yml) to provide a manual and file-change-triggered setup for Copilot-related .NET workloads. The job runs on ubuntu-latest, checks out the repo (actions/checkout@v4), installs .NET 10.x (actions/setup-dotnet@v4), and installs the maui-android workload using WORKLOAD_VERSION=10.0.103. Permissions are limited to contents: read.