### PR TITLE
Support iOS scene lifecycle and update templates

### DIFF
--- a/samples/HeadToHeadSpice/Platforms/iOS/AppDelegate.cs
+++ b/samples/HeadToHeadSpice/Platforms/iOS/AppDelegate.cs
@@ -3,4 +3,7 @@
 namespace HeadToHeadSpice;
 
 [Register("AppDelegate")]
-public class AppDelegate : SpiceAppDelegate<App> { }
+public class AppDelegate : SpiceAppDelegate
+{
+	public override Application CreateApplication() => new App();
+}

--- a/samples/HeadToHeadSpice/Platforms/iOS/Info.plist
+++ b/samples/HeadToHeadSpice/Platforms/iOS/Info.plist
@@ -33,7 +33,17 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 		<key>UISceneConfigurations</key>
-		<dict/>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SpiceSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/samples/Spice.BlazorSample/Platforms/iOS/AppDelegate.cs
+++ b/samples/Spice.BlazorSample/Platforms/iOS/AppDelegate.cs
@@ -3,4 +3,7 @@
 namespace Spice.BlazorSample;
 
 [Register("AppDelegate")]
-public class AppDelegate : SpiceAppDelegate<App> { }
+public class AppDelegate : SpiceAppDelegate
+{
+	public override Application CreateApplication() => new App();
+}

--- a/samples/Spice.BlazorSample/Platforms/iOS/Info.plist
+++ b/samples/Spice.BlazorSample/Platforms/iOS/Info.plist
@@ -33,7 +33,17 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 		<key>UISceneConfigurations</key>
-		<dict/>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SpiceSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/samples/Spice.Scenarios/Platforms/iOS/AppDelegate.cs
+++ b/samples/Spice.Scenarios/Platforms/iOS/AppDelegate.cs
@@ -3,4 +3,7 @@
 namespace Spice.Scenarios;
 
 [Register("AppDelegate")]
-public class AppDelegate : SpiceAppDelegate<App> { }
+public class AppDelegate : SpiceAppDelegate
+{
+	public override Application CreateApplication() => new App();
+}

--- a/samples/Spice.Scenarios/Platforms/iOS/Info.plist
+++ b/samples/Spice.Scenarios/Platforms/iOS/Info.plist
@@ -33,7 +33,17 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 		<key>UISceneConfigurations</key>
-		<dict/>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SpiceSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/src/Spice.Templates/templates/spice-blazor/Platforms/iOS/AppDelegate.cs
+++ b/src/Spice.Templates/templates/spice-blazor/Platforms/iOS/AppDelegate.cs
@@ -3,4 +3,7 @@
 namespace HelloBlazor;
 
 [Register("AppDelegate")]
-public class AppDelegate : SpiceAppDelegate<App> { }
+public class AppDelegate : SpiceAppDelegate
+{
+	public override Application CreateApplication() => new App();
+}

--- a/src/Spice.Templates/templates/spice-blazor/Platforms/iOS/Info.plist
+++ b/src/Spice.Templates/templates/spice-blazor/Platforms/iOS/Info.plist
@@ -33,7 +33,17 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 		<key>UISceneConfigurations</key>
-		<dict/>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SpiceSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/src/Spice.Templates/templates/spice/Platforms/iOS/AppDelegate.cs
+++ b/src/Spice.Templates/templates/spice/Platforms/iOS/AppDelegate.cs
@@ -3,4 +3,7 @@
 namespace Hello;
 
 [Register("AppDelegate")]
-public class AppDelegate : SpiceAppDelegate<App> { }
+public class AppDelegate : SpiceAppDelegate
+{
+	public override Application CreateApplication() => new App();
+}

--- a/src/Spice.Templates/templates/spice/Platforms/iOS/Info.plist
+++ b/src/Spice.Templates/templates/spice/Platforms/iOS/Info.plist
@@ -33,7 +33,17 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 		<key>UISceneConfigurations</key>
-		<dict/>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SpiceSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/src/Spice/MSBuild/Spice.targets
+++ b/src/Spice/MSBuild/Spice.targets
@@ -35,6 +35,10 @@
 		<CodesignEntitlements Condition=" '$(CodesignEntitlements)' == '' and Exists('$(iOSProjectFolder)Entitlements.plist') ">$(iOSProjectFolder)Entitlements.plist</CodesignEntitlements>
 	</PropertyGroup>
 
+	<ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' ">
+		<None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" Condition=" Exists('$(iOSProjectFolder)Info.plist') " />
+	</ItemGroup>
+
 	<ItemGroup Condition=" '$(SingleProject)' == 'true' ">
 		<!-- Add metadata indicating that the platform-specific files are not part of every build configuration. -->
 		<Compile Update="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)">

--- a/src/Spice/Platforms/iOS/Application.cs
+++ b/src/Spice/Platforms/iOS/Application.cs
@@ -23,7 +23,11 @@ public partial class Application
 	{
 		if (value != null)
 		{
-			AddSubview(value);
+			// The Main view should always fill the entire Application area
+			UIView native = value;
+			native.Frame = NativeView.Bounds;
+			native.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+			NativeView.AddSubview(native);
 		}
 	}
 }


### PR DESCRIPTION
Refactor iOS app lifecycle to use scene-based API and update samples/templates accordingly. Key changes:
- Introduce a registered SpiceSceneDelegate and make SpiceAppDelegate abstract with CreateApplication() to provide the root Application instance.
- Update SpiceSceneDelegate to create UIWindow, set a UIViewController root, assert view availability and set background color before adding the Application view.
- Update Application view handling to fill the entire area by setting Frame and AutoresizingMask when adding the native view.
- Add UISceneConfigurations entries to Info.plist files in samples and templates, pointing to SpiceSceneDelegate.
- Update sample/template AppDelegate.cs files to override CreateApplication() instead of using the generic SpiceAppDelegate<T> shorthand.
- MSBuild: include the platform Info.plist in single-project iOS builds so the scene manifest can be picked up.

These changes enable the modern iOS scene lifecycle for Spice apps and ensure templates/samples and build targets work with single-project setups.